### PR TITLE
feat: associate account type entity into account entity

### DIFF
--- a/src/main/java/com/matera/account/account/Account.java
+++ b/src/main/java/com/matera/account/account/Account.java
@@ -1,5 +1,7 @@
 package com.matera.account.account;
 
+import com.matera.account.accounttype.AccountType;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 import javax.persistence.*;
@@ -28,7 +30,9 @@ public class Account implements AccountProjection{
 
     private UUID clientId;
 
-    private Integer accountTypeId;
+    @ManyToOne
+    @JoinColumn(name = "account_type_id")
+    private AccountType accountTypeId;
 
     private String agency;
 
@@ -64,11 +68,11 @@ public class Account implements AccountProjection{
     }
 
     @Override
-    public Integer getAccountTypeId() {
+    public AccountType getAccountTypeId() {
         return accountTypeId;
     }
 
-    public void setAccountTypeId(Integer accountTypeId) {
+    public void setAccountTypeId(AccountType accountTypeId) {
         this.accountTypeId = accountTypeId;
     }
 

--- a/src/main/java/com/matera/account/account/Account.java
+++ b/src/main/java/com/matera/account/account/Account.java
@@ -5,6 +5,7 @@ import com.matera.account.accounttype.AccountType;
 import java.math.BigDecimal;
 import java.util.UUID;
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Entity
 public class Account implements AccountProjection{
@@ -16,7 +17,7 @@ public class Account implements AccountProjection{
     public Account(UUID clientId, AccountDTO accountDTO) {
         this.accountId = accountDTO.getAccountId();
         this.clientId = clientId;
-        this.accountTypeId = accountDTO.getAccountTypeId();
+        this.accountType = accountDTO.getAccountType();
         this.agency = accountDTO.getAgency();
         this.accountNumber = accountDTO.getAccountNumber();
         this.balance = accountDTO.getBalance();
@@ -32,7 +33,7 @@ public class Account implements AccountProjection{
 
     @ManyToOne
     @JoinColumn(name = "account_type_id")
-    private AccountType accountTypeId;
+    private AccountType accountType;
 
     private String agency;
 
@@ -68,12 +69,11 @@ public class Account implements AccountProjection{
     }
 
     @Override
-    public AccountType getAccountTypeId() {
-        return accountTypeId;
+    public AccountType getAccountType() {
+        return accountType;
     }
 
-    public void setAccountTypeId(AccountType accountTypeId) {
-        this.accountTypeId = accountTypeId;
+    public void setAccountType(AccountType accountType) {
     }
 
     @Override

--- a/src/main/java/com/matera/account/account/AccountController.java
+++ b/src/main/java/com/matera/account/account/AccountController.java
@@ -24,7 +24,6 @@ public class AccountController {
 
     @GetMapping("/clients/{clientId}/accounts/{accountId}")
     // Find Account by accountId
-
     public Account getAccountByAccountId(@PathVariable("clientId") UUID clientId, @PathVariable("accountId") UUID accountId) {
         return accountService.findAccountByAccountId(clientId, accountId);
     }

--- a/src/main/java/com/matera/account/account/AccountDTO.java
+++ b/src/main/java/com/matera/account/account/AccountDTO.java
@@ -1,5 +1,7 @@
 package com.matera.account.account;
 
+import com.matera.account.accounttype.AccountType;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -11,7 +13,7 @@ public class AccountDTO implements AccountProjection{
 
     private UUID clientId;
 
-    private Integer accountTypeId;
+    private AccountType accountTypeId;
 
     private String agency;
 
@@ -30,7 +32,7 @@ public class AccountDTO implements AccountProjection{
     }
 
     @Override
-    public Integer getAccountTypeId() {
+    public AccountType getAccountTypeId() {
         return accountTypeId;
     }
 

--- a/src/main/java/com/matera/account/account/AccountDTO.java
+++ b/src/main/java/com/matera/account/account/AccountDTO.java
@@ -2,6 +2,7 @@ package com.matera.account.account;
 
 import com.matera.account.accounttype.AccountType;
 
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -13,7 +14,8 @@ public class AccountDTO implements AccountProjection{
 
     private UUID clientId;
 
-    private AccountType accountTypeId;
+    @NotNull
+    private AccountType accountType;
 
     private String agency;
 
@@ -32,8 +34,8 @@ public class AccountDTO implements AccountProjection{
     }
 
     @Override
-    public AccountType getAccountTypeId() {
-        return accountTypeId;
+    public AccountType getAccountType() {
+        return accountType;
     }
 
     @Override

--- a/src/main/java/com/matera/account/account/AccountProjection.java
+++ b/src/main/java/com/matera/account/account/AccountProjection.java
@@ -11,7 +11,7 @@ public interface AccountProjection {
 
     UUID getClientId();
 
-    AccountType getAccountTypeId();
+    AccountType getAccountType();
 
     String getAgency();
 

--- a/src/main/java/com/matera/account/account/AccountProjection.java
+++ b/src/main/java/com/matera/account/account/AccountProjection.java
@@ -1,5 +1,7 @@
 package com.matera.account.account;
 
+import com.matera.account.accounttype.AccountType;
+
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -9,7 +11,7 @@ public interface AccountProjection {
 
     UUID getClientId();
 
-    Integer getAccountTypeId();
+    AccountType getAccountTypeId();
 
     String getAgency();
 

--- a/src/main/java/com/matera/account/account/AccountService.java
+++ b/src/main/java/com/matera/account/account/AccountService.java
@@ -40,7 +40,6 @@ public class AccountService {
         account.setAccountTypeId(accountDTO.getAccountTypeId());
         account.setAgency(accountDTO.getAgency());
         account.setBalance(accountDTO.getBalance());
-        account.setClientId(accountDTO.getClientId());
         accountRepository.save(account);
         return account;
     }

--- a/src/main/java/com/matera/account/account/AccountService.java
+++ b/src/main/java/com/matera/account/account/AccountService.java
@@ -37,7 +37,7 @@ public class AccountService {
         Account account = accountRepository.findByAccountIdAndClientId(clientId, accountId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Couldn't Found Account"));
         account.setAccountNumber(accountDTO.getAccountNumber());
-        account.setAccountTypeId(accountDTO.getAccountTypeId());
+        account.setAccountType(accountDTO.getAccountType());
         account.setAgency(accountDTO.getAgency());
         account.setBalance(accountDTO.getBalance());
         accountRepository.save(account);

--- a/src/main/java/com/matera/account/accounttype/AccountType.java
+++ b/src/main/java/com/matera/account/accounttype/AccountType.java
@@ -1,6 +1,7 @@
 package com.matera.account.accounttype;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Id;
 
 @Entity
 public class AccountType {

--- a/src/main/java/com/matera/account/accounttype/AccountType.java
+++ b/src/main/java/com/matera/account/accounttype/AccountType.java
@@ -9,6 +9,22 @@ public class AccountType {
     public int accountTypeId;
     public String accountType;
 
+    public int getAccountTypeId() {
+        return accountTypeId;
+    }
+
+    public void setAccountTypeId(int accountTypeId) {
+        this.accountTypeId = accountTypeId;
+    }
+
+    public String getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(String accountType) {
+        this.accountType = accountType;
+    }
+
 }
 
 

--- a/src/main/java/com/matera/account/accounttype/AccountType.java
+++ b/src/main/java/com/matera/account/accounttype/AccountType.java
@@ -1,0 +1,14 @@
+package com.matera.account.accounttype;
+
+import javax.persistence.*;
+
+@Entity
+public class AccountType {
+
+    @Id
+    public int accountTypeId;
+    public String accountType;
+
+}
+
+

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -91,3 +91,11 @@ databaseChangeLog:
                   name: client_id
                   type: uuid
 
+
+  - changeSet:
+      id: change account_type constraint nullable to false in account table
+      author: izumizawa
+      changes:
+        - addNotNullConstraint:
+            tableName: account
+            columnName: account_type_id


### PR DESCRIPTION
I created AccountType entity and associated into Account. AccountType would be an integer "1" or "2", now it's an Entity that returns and integer and a String. 
GET return example then:
{
    "accountId": UUID,
    "clientId": UUID,
    "accountTypeId": 2,
    "agency": "99",
    "accountNumber": "1234",
    "balance": 120
}


GET return example now:
{
    "accountId": UUID,
    "clientId": UUID,
    "accountType": {
        "accountTypeId": 2,
        "accountType": "Savings_Account"
    },
    "agency": "99",
    "accountNumber": "1234",
    "balance": 120
}